### PR TITLE
Fix: kv iterator now returns valid kv obj only.

### DIFF
--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -1638,7 +1638,7 @@ fdb_kv_iterator_t fdb_kv_iterator_init(fdb_kv_iterator_t itr)
  * @param db database object
  * @param itr the iterator structure
  *
- * @return false if iterate not ended, true if iterate ended.
+ * @return false if iteration is ended, true if iteration is not ended.
  */
 bool fdb_kv_iterate(fdb_kvdb_t db, fdb_kv_iterator_t itr)
 {

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -1645,28 +1645,28 @@ bool fdb_kv_iterate(fdb_kvdb_t db, fdb_kv_iterator_t itr)
     struct kvdb_sec_info sector;
     fdb_kv_t kv = &(itr->curr_kv);
     do {
-		if (read_sector_info(db, itr->sector_addr, &sector, false) == FDB_NO_ERR) {
-			if (sector.status.store == FDB_SECTOR_STORE_USING || sector.status.store == FDB_SECTOR_STORE_FULL) {
-				if (kv->addr.start == 0) {
-					kv->addr.start = sector.addr + SECTOR_HDR_DATA_SIZE;
-				}
-				else if ((kv->addr.start = get_next_kv_addr(db, &sector, kv)) == FAILED_ADDR) {
-					kv->addr.start = 0;
-					continue;
-				}
-				do {
-					read_kv(db, kv);
-					if (kv->status == FDB_KV_WRITE) {
-						/* We got a valid kv here. */
-						/* If iterator statistics is needed */
-						itr->iterated_cnt++;
-						itr->iterated_obj_bytes += kv->len;
-						itr->iterated_value_bytes += kv->value_len;
-						return true;
-					}
-				} while((kv->addr.start = get_next_kv_addr(db, &sector, kv)) != FAILED_ADDR);
-			}
-		}
+        if (read_sector_info(db, itr->sector_addr, &sector, false) == FDB_NO_ERR) {
+            if (sector.status.store == FDB_SECTOR_STORE_USING || sector.status.store == FDB_SECTOR_STORE_FULL) {
+                if (kv->addr.start == 0) {
+                    kv->addr.start = sector.addr + SECTOR_HDR_DATA_SIZE;
+                }
+                else if ((kv->addr.start = get_next_kv_addr(db, &sector, kv)) == FAILED_ADDR) {
+                    kv->addr.start = 0;
+                    continue;
+                }
+                do {
+                    read_kv(db, kv);
+                    if (kv->status == FDB_KV_WRITE) {
+                        /* We got a valid kv here. */
+                        /* If iterator statistics is needed */
+                        itr->iterated_cnt++;
+                        itr->iterated_obj_bytes += kv->len;
+                        itr->iterated_value_bytes += kv->value_len;
+                        return true;
+                    }
+                } while((kv->addr.start = get_next_kv_addr(db, &sector, kv)) != FAILED_ADDR);
+            }
+        }
         /** Set kv->addr.start to 0 when we get into a new sector so that if we successfully get the next sector info,
          *  the kv->addr.start is set to the new sector.addr + SECTOR_HDR_DATA_SIZE.
         */


### PR DESCRIPTION
fdb_kv_iterate() now returns kv object which status is FDB_KV_WRITE only, as most users have no interest in deprecated KVs