### PR TITLE
[fdb] Fix mismatch with the comments for status migration when FDB_WR…

### DIFF
--- a/src/fdb_utils.c
+++ b/src/fdb_utils.c
@@ -102,7 +102,7 @@ size_t _fdb_set_status(uint8_t status_table[], size_t status_num, size_t status_
     if (status_index > 0) {
 #if (FDB_WRITE_GRAN == 1)
         byte_index = (status_index - 1) / 8;
-        status_table[byte_index] &= ~(0x80 >> ((status_index - 1) % 8));
+        status_table[byte_index] &= (0x00ff >> (status_index % 8));
 #else
         byte_index = (status_index - 1) * (FDB_WRITE_GRAN / 8);
         status_table[byte_index] = 0x00;


### PR DESCRIPTION
我在测试 gd32f450 板卡测试,当我设置 ``FDB_WRITE_GRAN == 1`` 时, 我发现在 status 状态的迁移是 0x7F -> 0xBF, 而不是设计的 0x7F -> 0x3F,导致在 1 bit 模式时总是写数据不成功.
![](https://s3.bmp.ovh/imgs/2021/08/34b6d17e1f82b104.png)
修改后,重新测试.
![](https://s3.bmp.ovh/imgs/2021/08/ac1240e7b1ef85e7.png)
目前测试 1bit 模式在 gd32f450zit6 可以正常使用.测试日志:
```text

msh />reset
reset: command not found.
msh />
 \ | /
- RT -     Thread Operating System
 / | \     4.0.4 build Aug 16 2021
 2006 - 2021 Copyright by rt-thread team
[I/drv.encoder] Hello screen
[D/FAL] (fal_flash_init:63) Flash device |            gd32f4_onchip | addr: 0x08000000 | len: 0x00100000 | blk_size: 0x00020000 |initialized finish.
[I/FAL] ==================== FAL partition table ====================
[I/FAL] | name | flash_dev     |   offset   |    length  |
[I/FAL] -------------------------------------------------------------
[I/FAL] | bl   | gd32f4_onchip | 0x00000000 | 0x00080000 |
[I/FAL] | sys  | gd32f4_onchip | 0x00080000 | 0x00080000 |
[I/FAL] =============================================================
[I/FAL] RT-Thread Flash Abstraction Layer (V0.5.0) initialize success.
[FlashDB][kv][syscfg] (packages/FlashDB-latest/src/fdb_kvdb.c:1614) KVDB size is 524288 bytes.
[FlashDB] FlashDB V1.0.99 is initialize success.
[FlashDB] You can get the latest version on https://github.com/armink/FlashDB .
[I/app.MAIN] init sysconfig ret=0.
[I/app.MAIN] ==================== kvdb_basic_sample ====================

[I/app.MAIN] get the 'bootcounts' value is 13

[I/app.MAIN] tc start.
err--------, errtype=100050
msh />
 \ | /
- RT -     Thread Operating System
 / | \     4.0.4 build Aug 16 2021
 2006 - 2021 Copyright by rt-thread team
[I/drv.encoder] Hello screen
[D/FAL] (fal_flash_init:63) Flash device |            gd32f4_onchip | addr: 0x08000000 | len: 0x00100000 | blk_size: 0x00020000 |initialized finish.
[I/FAL] ==================== FAL partition table ====================
[I/FAL] | name | flash_dev     |   offset   |    length  |
[I/FAL] -------------------------------------------------------------
[I/FAL] | bl   | gd32f4_onchip | 0x00000000 | 0x00080000 |
[I/FAL] | sys  | gd32f4_onchip | 0x00080000 | 0x00080000 |
[I/FAL] =============================================================
[I/FAL] RT-Thread Flash Abstraction Layer (V0.5.0) initialize success.
[FlashDB][kv][syscfg] (packages/FlashDB-latest/src/fdb_kvdb.c:1614) KVDB size is 524288 bytes.
[FlashDB] FlashDB V1.0.99 is initialize success.
[FlashDB] You can get the latest version on https://github.com/armink/FlashDB .
[I/app.MAIN] init sysconfig ret=0.
[I/app.MAIN] ==================== kvdb_basic_sample ====================

[I/app.MAIN] get the 'bootcounts' value is 14

[I/app.MAIN] tc start.
err--------, errtype=100050
msh />
 \ | /
- RT -     Thread Operating System
 / | \     4.0.4 build Aug 16 2021
 2006 - 2021 Copyright by rt-thread team
[I/drv.encoder] Hello screen
[D/FAL] (fal_flash_init:63) Flash device |            gd32f4_onchip | addr: 0x08000000 | len: 0x00100000 | blk_size: 0x00020000 |initialized finish.
[I/FAL] ==================== FAL partition table ====================
[I/FAL] | name | flash_dev     |   offset   |    length  |
[I/FAL] -------------------------------------------------------------
[I/FAL] | bl   | gd32f4_onchip | 0x00000000 | 0x00080000 |
[I/FAL] | sys  | gd32f4_onchip | 0x00080000 | 0x00080000 |
[I/FAL] =============================================================
[I/FAL] RT-Thread Flash Abstraction Layer (V0.5.0) initialize success.
[FlashDB][kv][syscfg] (packages/FlashDB-latest/src/fdb_kvdb.c:1614) KVDB size is 524288 bytes.
[FlashDB] FlashDB V1.0.99 is initialize success.
[FlashDB] You can get the latest version on https://github.com/armink/FlashDB .
[I/app.MAIN] init sysconfig ret=0.
[I/app.MAIN] ==================== kvdb_basic_sample ====================

[I/app.MAIN] get the 'bootcounts' value is 15

[I/app.MAIN] tc start.
err--------, errtype=180050
msh />
```