### PR TITLE
Add hash index to speed up searching

### DIFF
--- a/demos/linux/applications/fdb_cfg.h
+++ b/demos/linux/applications/fdb_cfg.h
@@ -25,11 +25,15 @@
 
 /* Using file storage mode by POSIX file API, like open/read/write/close */
 #define FDB_USING_FILE_POSIX_MODE
+//#define FDB_USING_FILE_LIBC_MODE
 
 /* log print macro. default EF_PRINT macro is printf() */
 /* #define FDB_PRINT(...)              my_printf(__VA_ARGS__) */
 
 /* print debug information */
 #define FDB_DEBUG_ENABLE
+
+/* enable hash enhancement, open it can speed up searhing */
+//#define FDB_KV_CACHE_HASH_ENHANCEMENT
 
 #endif /* _FDB_CFG_H_ */

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,3 +39,6 @@ The print function macro defines the configuration. When it is not configured by
 ## FDB_DEBUG_ENABLE
 
 Enable debugging information output. When this configuration is closed, the system will not output logs for debugging.
+
+## FDB_KV_CACHE_HASHINDEX_ENHANCEMENT
+Enable the enhancement of the KV cache, it will take more RAM but improve the search speed, it will create a hash-base index in memory. It will take 4-bytes for a key-value entry.

--- a/inc/fdb_def.h
+++ b/inc/fdb_def.h
@@ -322,6 +322,8 @@ struct fdb_kvdb {
     struct sector_cache_node sector_cache_table[FDB_SECTOR_CACHE_TABLE_SIZE];
 #ifdef FDB_KV_CACHE_HASH_ENHANCEMENT
     /* KV hash enhancement */
+    bool kv_cache_enm_collisions;
+    bool kv_cache_table_collisions;
     size_t kv_cache_enm_total_size;
     size_t kv_cache_enm_size;
     fdb_cache_hash_enhancement_ops_t kv_cache_enm_ops;

--- a/inc/fdb_def.h
+++ b/inc/fdb_def.h
@@ -287,7 +287,11 @@ struct fdb_db {
 };
 
 #ifdef FDB_KV_CACHE_HASH_ENHANCEMENT
-/* memory ops */
+/* memory ops,
+   In some complicated situations, the memory may use page-management, 
+   so the functions designed to switch pages before accessing,
+    or meet other prerequisites.
+ */
 struct fdb_cache_hash_enhancement_ops
 {
     /* init call when need init, please return the size of memory that allocated */

--- a/samples/kvdb_benchmark_sample.c
+++ b/samples/kvdb_benchmark_sample.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, LianYang, <lian.yang.cn@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief benchmark KV samples.
+ *
+ * write some KV entries and read it out
+ */
+
+#include <flashdb.h>
+#include <string.h>
+
+#ifdef FDB_USING_KVDB
+
+#define FDB_LOG_TAG "[sample][kvdb][bench]"
+
+#define ROUND (200)
+
+void kvdb_bench_sample(fdb_kvdb_t kvdb)
+{
+    struct fdb_blob blob;
+    char bench_key[FDB_KV_NAME_MAX];
+    char bench_value[FDB_KV_NAME_MAX];
+
+    FDB_INFO("==================== kvdb_bench_sample ====================\n");
+
+    if (fdb_kv_get(kvdb, "1")==NULL)
+    { /* SET the KV value */
+        for (int i = 0; i<ROUND; i++) {
+            snprintf(bench_key, FDB_KV_NAME_MAX-1, "%d", i);
+            snprintf(bench_value, FDB_KV_NAME_MAX-1, "VALUE%d", i);
+
+            fdb_kv_set(kvdb, bench_key, bench_value);
+            FDB_INFO("set the '%8s' value to %12s\n", bench_key, bench_value);
+        }
+    }
+    
+    { /* GET the KV value */
+        for (int i = 0; i<ROUND; i++ ) {
+            snprintf(bench_key, FDB_KV_NAME_MAX-1, "%d", i);
+
+            char* read_value = fdb_kv_get(kvdb, bench_key);
+            FDB_INFO("get the '%8s' value is %12s\n", bench_key, read_value);
+        }
+    }
+
+    FDB_INFO("===========================================================\n");
+}
+
+#endif /* FDB_USING_KVDB */

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -301,7 +301,7 @@ static int kv_hash_put(fdb_kvdb_t db, const char *const key,
           break;
           case 2:
           /* update */
-          if (addr!= FDB_DATA_UNUSED) {
+          if (addr == FDB_DATA_UNUSED) {
             // delete
             db->kv_cache_enm_size--;
           }


### PR DESCRIPTION
1. This patch allows you to boost searching from O(n) to O(1)
2. Because the implementation is based on the hash, it has to take more memory to store the index data.
3. And each key-value entry takes 4 bytes.
4. More details please reference the "Demos/Linux"