### PR TITLE
update for RT-Thread v4.1.0

### DIFF
--- a/port/fal/inc/fal_def.h
+++ b/port/fal/inc/fal_def.h
@@ -30,6 +30,15 @@
 
 #define FAL_SW_VERSION                 "0.5.0"
 
+#ifdef __RTTHREAD__ /* for RT-Thread platform */
+#include <rtthread.h>
+#define FAL_PRINTF      rt_kprintf
+#define FAL_MALLOC      rt_malloc
+#define FAL_CALLOC      rt_calloc
+#define FAL_REALLOC     rt_realloc
+#define FAL_FREE        rt_free
+#endif
+
 #ifndef FAL_MALLOC
 #define FAL_MALLOC                     malloc
 #endif
@@ -46,19 +55,13 @@
 #define FAL_FREE                       free
 #endif
 
+#ifndef FAL_PRINTF
+#define FAL_PRINTF                     printf
+#endif
+
 #ifndef FAL_DEBUG
 #define FAL_DEBUG                      0
 #endif
-
-#ifndef FAL_PRINTF
-#ifdef RT_VER_NUM
-/* for RT-Thread platform */
-extern void rt_kprintf(const char *fmt, ...);
-#define FAL_PRINTF rt_kprintf
-#else
-#define FAL_PRINTF printf
-#endif /* RT_VER_NUM */
-#endif /* FAL_PRINTF */
 
 #if FAL_DEBUG
 #ifdef assert


### PR DESCRIPTION
在rtt4.1.0中，rt_kprintf增加了返回值功能，以符合ISO C标准。 因此不建议使用extern的方式，直接#include <rtthread.h>即可。此外从4.0.3版本往后，RTT增加了__RTTHREAD__全局宏来进行OS判断（目的是为了在其他上游软件包中，可以与nuttx zephyr linux区分开），因此新版本的软件包可以采用__RTTHREAD__宏来直接判断