### PR TITLE
Circular scanning of free sectors in kv_alloc()

### DIFF
--- a/inc/fdb_cfg.h
+++ b/inc/fdb_cfg.h
@@ -44,6 +44,9 @@
 /* log print macro. default EF_PRINT macro is printf() */
 /* #define FDB_PRINT(...)              my_printf(__VA_ARGS__) */
 
+/* allocate flash sectors in circular pattern */
+#define FDB_CIRCULAR_ALLOC
+
 /* print debug information */
 #define FDB_DEBUG_ENABLE
 

--- a/inc/fdb_def.h
+++ b/inc/fdb_def.h
@@ -290,6 +290,7 @@ struct fdb_kvdb {
     struct fdb_kv cur_kv;
     struct kvdb_sec_info cur_sector;
     bool last_is_complete_del;
+    uint32_t last_using_addr;                    /**< limit allocs to sectors beyond this address */
 
 #ifdef FDB_KV_USING_CACHE
     /* KV cache table */


### PR DESCRIPTION
With this patch alloc_kv() will scan sectors in a circular fashion, instead of starting from the first sector every time. Alloc_kv will check the sectors in sector cache first, and then continue scanning from the sector it found during the previous alloc. This improves write performance when total number of sectors is large, as fully used sectors no longer need to be inspected.

The improvement should be clearly noticeable when writing to the last sectors of a large kvdb. I used it on a 512 kb flash region, with each sector 4 kb in size.