### PR TITLE
[kvdb] improve kvdb cache algo when key was first found

### DIFF
--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -221,11 +221,11 @@ static void update_kv_cache(fdb_kvdb_t db, const char *name, size_t name_len, ui
     if (empty_index < FDB_KV_CACHE_TABLE_SIZE) {
         db->kv_cache_table[empty_index].addr = addr;
         db->kv_cache_table[empty_index].name_crc = name_crc;
-        db->kv_cache_table[empty_index].active = 0;
+        db->kv_cache_table[empty_index].active = FDB_KV_CACHE_TABLE_SIZE;
     } else if (min_activity_index < FDB_KV_CACHE_TABLE_SIZE) {
         db->kv_cache_table[min_activity_index].addr = addr;
         db->kv_cache_table[min_activity_index].name_crc = name_crc;
-        db->kv_cache_table[min_activity_index].active = 0;
+        db->kv_cache_table[min_activity_index].active = FDB_KV_CACHE_TABLE_SIZE;
     }
 }
 


### PR DESCRIPTION
修复场景：
当cache满的情况下，更新一个新的key值 A 到cache后，因为初始化的active为0，导致下一个key值 B 再更新到cache里，会把 A给删除。使得满cache的情况下，每次更新key值，都会把上一个key值给从cache中删除。