### PR TITLE
[inc/fdb_low_lvl] fix An error occurred in FDB_ALIGN(size, align)

### DIFF
--- a/inc/fdb_low_lvl.h
+++ b/inc/fdb_low_lvl.h
@@ -29,7 +29,7 @@
 /* Return the most contiguous size aligned at specified width. RT_ALIGN(13, 4)
  * would return 16.
  */
-#define FDB_ALIGN(size, align)                    (((size) + (align) - 1) & ~((align) - 1))
+#define FDB_ALIGN(size, align)                    ((size + align - 1) - ((size + align -1) % align))
 /* align by write granularity */
 #define FDB_WG_ALIGN(size)                        (FDB_ALIGN(size, (FDB_WRITE_GRAN + 7)/8))
 /**


### PR DESCRIPTION
An error occurred in FDB_ALIGN(size, align) when align is not 2 to the nth power.

The following is the minimal unit test code for the new implementation:

```
#include <stdio.h>
#define FDB_ALIGN(size, align)                      ((size + align -1) - ((size + align -1) % align))
void main(void)
{
    printf("FDB_ALIGN(0, 8) : %d\n", FDB_ALIGN(0, 8));
    printf("FDB_ALIGN(0, 10) : %d\n", FDB_ALIGN(0, 10));
    printf("FDB_ALIGN(10, 10) : %d\n", FDB_ALIGN(10, 10));
    printf("FDB_ALIGN(10, 20) : %d\n", FDB_ALIGN(10, 20));
    printf("FDB_ALIGN(20, 20) : %d\n", FDB_ALIGN(20, 20));
    printf("FDB_ALIGN(20, 10) : %d\n", FDB_ALIGN(20, 10));
    printf("FDB_ALIGN(10, 8) : %d\n", FDB_ALIGN(10, 8));
    printf("FDB_ALIGN(10, 7) : %d\n", FDB_ALIGN(10, 7));
    printf("FDB_ALIGN(7, 10) : %d\n", FDB_ALIGN(7, 10));
    printf("FDB_ALIGN(7, 20) : %d\n", FDB_ALIGN(7, 20));
    printf("FDB_ALIGN(32, 16) : %d\n", FDB_ALIGN(32, 16));
    printf("FDB_ALIGN(100, 16) : %d\n", FDB_ALIGN(100, 16));
    printf("FDB_ALIGN(100, 17) : %d\n", FDB_ALIGN(100, 17));
}
```

The following is the test results:
```
FDB_ALIGN(0, 8) : 0
FDB_ALIGN(0, 10) : 0
FDB_ALIGN(10, 10) : 10
FDB_ALIGN(10, 20) : 20
FDB_ALIGN(20, 20) : 20
FDB_ALIGN(20, 10) : 20
FDB_ALIGN(10, 8) : 16
FDB_ALIGN(10, 7) : 14
FDB_ALIGN(7, 10) : 10
FDB_ALIGN(7, 20) : 20
FDB_ALIGN(32, 16) : 32
FDB_ALIGN(100, 16) : 112
FDB_ALIGN(100, 17) : 102
```