### PR TITLE
Replaced `~0UL` in max value checks

### DIFF
--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -341,7 +341,7 @@ static fdb_err_t read_kv(fdb_kvdb_t db, fdb_kv_t kv)
     kv->status = (fdb_kv_status_t) _fdb_get_status(kv_hdr.status_table, FDB_KV_STATUS_NUM);
     kv->len = kv_hdr.len;
 
-    if (kv->len == ~0UL || kv->len > db_max_size(db) || kv->len < KV_HDR_DATA_SIZE) {
+    if (kv->len == UINT32_MAX || kv->len > db_max_size(db) || kv->len < KV_HDR_DATA_SIZE) {
         /* the KV length was not write, so reserved the info for current KV */
         kv->len = KV_HDR_DATA_SIZE;
         if (kv->status != FDB_KV_ERR_HDR) {

--- a/src/fdb_utils.c
+++ b/src/fdb_utils.c
@@ -90,7 +90,7 @@ uint32_t fdb_calc_crc32(uint32_t crc, const void *buf, size_t size)
 
 size_t _fdb_set_status(uint8_t status_table[], size_t status_num, size_t status_index)
 {
-    size_t byte_index = ~0UL;
+    size_t byte_index = SIZE_MAX;
     /*
      * | write garn |       status0       |       status1       |      status2         |       status3      |
      * ------------------------------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ fdb_err_t _fdb_write_status(fdb_db_t db, uint32_t addr, uint8_t status_table[], 
     byte_index = _fdb_set_status(status_table, status_num, status_index);
 
     /* the first status table value is all 1, so no need to write flash */
-    if (byte_index == ~0UL) {
+    if (byte_index == SIZE_MAX) {
         return FDB_NO_ERR;
     }
 #if (FDB_WRITE_GRAN == 1)


### PR DESCRIPTION
The actual value of `~0UL` is architecture dependent. The `unsigned long` type must be at least 32 bits, but can be larger. Especially on 64-bit systems, `unsigned long` usually is 64 bits long, for which `~0UL` will result in `0xFFFFFFFFFFFFFFFF` instead of `0xFFFFFFFF`. If this is the case, comparisons like `kv->len == ~0UL`, where `kv->len` is of type `uint32_t`, are always false. This commit replaces `~0UL` with the appropriate max value defines from stdint.h.