### PR TITLE
Support 128bit write granularity for kvdb

### DIFF
--- a/inc/fdb_cfg.h
+++ b/inc/fdb_cfg.h
@@ -28,7 +28,7 @@
 
 #ifdef FDB_USING_FAL_MODE
 /* the flash write granularity, unit: bit
- * only support 1(nor flash)/ 8(stm32f2/f4)/ 32(stm32f1) */
+ * only support 1(nor flash)/ 8(stm32f2/f4)/ 32(stm32f1)/ 64(stm32f7)/ 128(stm32h5) */
 #define FDB_WRITE_GRAN                /* @note you must define it for a value */
 #endif
 

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -28,7 +28,7 @@
 #endif
 
 #if FDB_WRITE_GRAN != 1 && FDB_WRITE_GRAN != 8 && FDB_WRITE_GRAN != 32 && FDB_WRITE_GRAN != 64 && FDB_WRITE_GRAN != 128
-#error "the write gran can be only setting as 1, 8, 32 and 64"
+#error "the write gran can be only setting as 1, 8, 32, 64 and 128"
 #endif
 
 /* magic word(`F`, `D`, `B`, `1`) */
@@ -120,7 +120,7 @@ struct kv_hdr_data {
     uint8_t padding[4];                          /**< align padding for 64bit write granularity */
 #endif
 #if (FDB_WRITE_GRAN == 128)
-    uint8_t padding[4 + 8];                      /**< align padding for 128bit write granularity */
+    uint8_t padding[12];                         /**< align padding for 128bit write granularity */
 #endif
 };
 typedef struct kv_hdr_data *kv_hdr_data_t;

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -27,7 +27,7 @@
 #error "Please configure flash write granularity (in fdb_cfg.h)"
 #endif
 
-#if FDB_WRITE_GRAN != 1 && FDB_WRITE_GRAN != 8 && FDB_WRITE_GRAN != 32 && FDB_WRITE_GRAN != 64
+#if FDB_WRITE_GRAN != 1 && FDB_WRITE_GRAN != 8 && FDB_WRITE_GRAN != 32 && FDB_WRITE_GRAN != 64 && FDB_WRITE_GRAN != 128
 #error "the write gran can be only setting as 1, 8, 32 and 64"
 #endif
 
@@ -103,8 +103,8 @@ struct sector_hdr_data {
     uint32_t magic;                              /**< magic word(`E`, `F`, `4`, `0`) */
     uint32_t combined;                           /**< the combined next sector number, 0xFFFFFFFF: not combined */
     uint32_t reserved;
-#if (FDB_WRITE_GRAN == 64)
-    uint8_t padding[4];                          /**< align padding for 64bit write granularity */
+#if (FDB_WRITE_GRAN == 64) || (FDB_WRITE_GRAN == 128)
+    uint8_t padding[4];                          /**< align padding for 64bit and 128bit write granularity */
 #endif
 };
 typedef struct sector_hdr_data *sector_hdr_data_t;
@@ -118,6 +118,9 @@ struct kv_hdr_data {
     uint32_t value_len;                          /**< value length */
 #if (FDB_WRITE_GRAN == 64)
     uint8_t padding[4];                          /**< align padding for 64bit write granularity */
+#endif
+#if (FDB_WRITE_GRAN == 128)
+    uint8_t padding[4 + 8];                      /**< align padding for 128bit write granularity */
 #endif
 };
 typedef struct kv_hdr_data *kv_hdr_data_t;

--- a/src/fdb_tsdb.c
+++ b/src/fdb_tsdb.c
@@ -25,8 +25,8 @@
 
 #if defined(FDB_USING_TSDB)
 
-#if (FDB_WRITE_GRAN == 64)
-#error "Flash 64 bits write granularity is not supported in TSDB yet!"
+#if (FDB_WRITE_GRAN == 64) || (FDB_WRITE_GRAN == 128)
+#error "Flash 64 or 128 bits write granularity is not supported in TSDB yet!"
 #endif
 
 /* magic word(`T`, `S`, `L`, `0`) */


### PR DESCRIPTION
The new stm32h5xx MCUs only support quad word (128bit) writes to flash. Tested with this driver:

https://github.com/tinic/lightkraken2/blob/main/support/fal_stm32h5xx.c