### PR TITLE
interrupt iteraotor when read_section_info fails

### DIFF
--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -837,7 +837,8 @@ static void sector_iterator(fdb_kvdb_t db, kv_sec_info_t sector, fdb_sector_stor
     sec_addr = db_oldest_addr(db);
     do {
         traversed_len += db_sec_size(db);
-        if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, false))return;
+        if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, false))
+            return;
         if (status == FDB_SECTOR_STORE_UNUSED || status == sector->status.store) {
             if (traversal_kv) {
                 if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, true))return;

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -841,7 +841,8 @@ static void sector_iterator(fdb_kvdb_t db, kv_sec_info_t sector, fdb_sector_stor
             return;
         if (status == FDB_SECTOR_STORE_UNUSED || status == sector->status.store) {
             if (traversal_kv) {
-                if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, true))return;
+                if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, true))
+                    return;
             }
             /* iterator is interrupted when callback return true */
             if (callback && callback(sector, arg1, arg2)) {

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -837,10 +837,10 @@ static void sector_iterator(fdb_kvdb_t db, kv_sec_info_t sector, fdb_sector_stor
     sec_addr = db_oldest_addr(db);
     do {
         traversed_len += db_sec_size(db);
-        read_sector_info(db, sec_addr, sector, false);
+        if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, false))return;
         if (status == FDB_SECTOR_STORE_UNUSED || status == sector->status.store) {
             if (traversal_kv) {
-                read_sector_info(db, sec_addr, sector, true);
+                if (FDB_NO_ERR != read_sector_info(db, sec_addr, sector, true))return;
             }
             /* iterator is interrupted when callback return true */
             if (callback && callback(sector, arg1, arg2)) {


### PR DESCRIPTION
`sector->status.store` will be uninitialized when read_section_info fails.

log of Valgrind when read_section_info fails.

```
==175190== Conditional jump or move depends on uninitialised value(s)
==175190==    at 0x8B754F: check_oldest_addr_cb (fdb_kvdb.c:1666)
==175190==    by 0x8B433A: sector_iterator (fdb_kvdb.c:927)
==175190==    by 0x8B865A: fdb_kvdb_init (fdb_kvdb.c:1906)
...
```

![image](https://github.com/armink/FlashDB/assets/88232613/90b3a5a4-d684-4d39-9152-cd9e9f401b6a)

