### PR TITLE
Add ability to append TSDB value at specific timestamp

### DIFF
--- a/inc/flashdb.h
+++ b/inc/flashdb.h
@@ -59,6 +59,7 @@ bool              fdb_kv_iterate      (fdb_kvdb_t db, fdb_kv_iterator_t itr);
 
 /* Time series log API like a TSDB */
 fdb_err_t  fdb_tsl_append      (fdb_tsdb_t db, fdb_blob_t blob);
+fdb_err_t  fdb_tsl_append_with_ts(fdb_tsdb_t db, fdb_blob_t blob, fdb_time_t timestamp);
 void       fdb_tsl_iter        (fdb_tsdb_t db, fdb_tsl_cb cb, void *cb_arg);
 void       fdb_tsl_iter_reverse(fdb_tsdb_t db, fdb_tsl_cb cb, void *cb_arg);
 void       fdb_tsl_iter_by_time(fdb_tsdb_t db, fdb_time_t from, fdb_time_t to, fdb_tsl_cb cb, void *cb_arg);

--- a/src/fdb_tsdb.c
+++ b/src/fdb_tsdb.c
@@ -381,10 +381,10 @@ static fdb_err_t update_sec_status(fdb_tsdb_t db, tsdb_sec_info_t sector, fdb_bl
     return result;
 }
 
-static fdb_err_t tsl_append(fdb_tsdb_t db, fdb_blob_t blob)
+static fdb_err_t tsl_append(fdb_tsdb_t db, fdb_blob_t blob, fdb_time_t *timestamp)
 {
     fdb_err_t result = FDB_NO_ERR;
-    fdb_time_t cur_time = db->get_time();
+    fdb_time_t cur_time = timestamp == NULL ? db->get_time() : *timestamp;
 
     /* check the append length, MUST less than the db->max_len */
     if(blob->size > db->max_len)
@@ -441,7 +441,31 @@ fdb_err_t fdb_tsl_append(fdb_tsdb_t db, fdb_blob_t blob)
     }
 
     db_lock(db);
-    result = tsl_append(db, blob);
+    result = tsl_append(db, blob, NULL);
+    db_unlock(db);
+
+    return result;
+}
+
+/**
+ * Append a new log to TSDB with specific timestamp.
+ *
+ * @param db database object
+ * @param blob log blob data
+ *
+ * @return result
+ */
+fdb_err_t fdb_tsl_append_with_ts(fdb_tsdb_t db, fdb_blob_t blob, fdb_time_t timestamp)
+{
+    fdb_err_t result = FDB_NO_ERR;
+
+    if (!db_init_ok(db)) {
+        FDB_INFO("Error: TSL (%s) isn't initialize OK.\n", db_name(db));
+        return FDB_INIT_FAILED;
+    }
+
+    db_lock(db);
+    result = tsl_append(db, blob, &timestamp);
     db_unlock(db);
 
     return result;


### PR DESCRIPTION
Hi.
In some cases it's necessary to save previously collected TSDB items at a specific timestamp. Real life example: I have a log entries that occurs before application receive valid time from NTP. I'm buffering those log entries in vector together with application uptime when the event occured. Then, when app receive a time from NTP, I'm saving collected log entries into TSDB with adjusted timestamp.