### PR TITLE
[fdb_kvdb]: fix shadow warning

### DIFF
--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -485,8 +485,8 @@ static fdb_err_t read_sector_info(fdb_kvdb_t db, uint32_t addr, kv_sec_info_t se
 #ifdef FDB_KV_USING_CACHE
         update_sector_cache(db, sector);
     } else {
-        kv_sec_info_t sector_cache = get_sector_from_cache(db, sector->addr);
-        if (!sector_cache) {
+        kv_sec_info_t sec_cache = get_sector_from_cache(db, sector->addr);
+        if (!sec_cache) {
             sector->empty_kv = FAILED_ADDR;
             sector->remain = 0;
             update_sector_cache(db, sector);


### PR DESCRIPTION
```bash
FlashDB/src/fdb_kvdb.c: In function ‘read_sector_info’:
FlashDB/src/fdb_kvdb.c:488:23: warning: declaration of ‘sector_cache’ shadows a previous local [-Wshadow]
  488 |         kv_sec_info_t sector_cache = get_sector_from_cache(db, sector->addr);
      |                       ^~~~~~~~~~~~
FlashDB/src/fdb_kvdb.c:421:19: note: shadowed declaration is here
  421 |     kv_sec_info_t sector_cache = get_sector_from_cache(db, addr);
      |                   ^~~~~~~~~~~~
```