### PR TITLE
Fixes to build for IDF w/o errors

### DIFF
--- a/demos/esp32_spi_flash/CMakeLists.txt
+++ b/demos/esp32_spi_flash/CMakeLists.txt
@@ -7,4 +7,6 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 list(APPEND EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/components")
 
+add_compile_definitions(FDB_USING_TIMESTAMP_64BIT)
 project(esp32_spi_flash)
+idf_build_set_property(COMPILE_OPTIONS "-Wno-error=maybe-uninitialized" APPEND)

--- a/samples/tsdb_sample.c
+++ b/samples/tsdb_sample.c
@@ -21,7 +21,7 @@
 #define FDB_LOG_TAG "[sample][tsdb]"
 
 #ifdef FDB_USING_TIMESTAMP_64BIT
-#define __PRITS "ld"
+#define __PRITS "lld"
 #else
 #define __PRITS "d"
 #endif

--- a/src/fdb.c
+++ b/src/fdb.c
@@ -74,7 +74,7 @@ fdb_err_t _fdb_init_ex(fdb_db_t db, const char *name, const char *path, fdb_db_t
         } else {
             /* must be aligned with block size */
             if (db->sec_size % block_size != 0) {
-                FDB_INFO("Error: db sector size (%" PRIu32 ") MUST align with block size (%" PRIu32 ").\n", db->sec_size, block_size);
+                FDB_INFO("Error: db sector size (%" PRIu32 ") MUST align with block size (%zu).\n", db->sec_size, block_size);
                 return FDB_INIT_FAILED;
             }
         }


### PR DESCRIPTION
@armink can you review these changes?

- size_t should be `zu` as per the discussion here - https://github.com/espressif/esp-idf/issues/11319#issuecomment-1533083268
- there are some uninitialzied errors that I have treated as warnings in cmake
- I have included the switch to 64 bit time stamps - I can remove that if you want.