### PR TITLE
[fdb_utils][_fdb_flash_write]: fix returned incorrect error code.

### DIFF
--- a/src/fdb_utils.c
+++ b/src/fdb_utils.c
@@ -304,7 +304,7 @@ fdb_err_t _fdb_flash_write(fdb_db_t db, uint32_t addr, const void *buf, size_t s
 #ifdef FDB_USING_FILE_MODE
         return _fdb_file_write(db, addr, buf, size, sync);
 #else
-        return FDB_READ_ERR;
+        return FDB_WRITE_ERR;
 #endif /* FDB_USING_FILE_MODE */
     } else {
 #ifdef FDB_USING_FAL_MODE


### PR DESCRIPTION
If user has set file mode, but file mode is disabled, _fdb_flash_write should return FDB_WRITE_ERR, not FDB_READ_ERR.