### PR TITLE
warnings fix

### DIFF
--- a/samples/tsdb_sample.c
+++ b/samples/tsdb_sample.c
@@ -92,7 +92,7 @@ void tsdb_sample(fdb_tsdb_t tsdb)
 static bool query_cb(fdb_tsl_t tsl, void *arg)
 {
     struct fdb_blob blob;
-    struct env_status status;
+    struct env_status status = {0, 0};
     fdb_tsdb_t db = arg;
 
     fdb_blob_read((fdb_db_t) db, fdb_tsl_to_blob(tsl, fdb_blob_make(&blob, &status, sizeof(status))));
@@ -104,7 +104,7 @@ static bool query_cb(fdb_tsl_t tsl, void *arg)
 static bool query_by_time_cb(fdb_tsl_t tsl, void *arg)
 {
     struct fdb_blob blob;
-    struct env_status status;
+    struct env_status status = {0, 0};
     fdb_tsdb_t db = arg;
 
     fdb_blob_read((fdb_db_t) db, fdb_tsl_to_blob(tsl, fdb_blob_make(&blob, &status, sizeof(status))));

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -390,7 +390,7 @@ static fdb_err_t read_kv(fdb_kvdb_t db, fdb_kv_t kv)
         /* try read the KV name, maybe read name has error */
         kv_name_addr = kv->addr.start + KV_HDR_DATA_SIZE;
         _fdb_flash_read((fdb_db_t)db, kv_name_addr, (uint32_t *)kv->name, FDB_WG_ALIGN(name_len));
-        FDB_INFO("Error: Read the KV (%.*s@0x%08" PRIX32 ") CRC32 check failed!\n", name_len, kv->name, kv->addr.start);
+        FDB_INFO("Error: Read the KV (%.*s@0x%08" PRIX32 ") CRC32 check failed!\n", (int)name_len, kv->name, kv->addr.start);
     } else {
         kv->crc_is_ok = true;
         /* the name is behind aligned KV header */
@@ -1076,7 +1076,7 @@ __retry:
             already_gc = true;
             goto __retry;
         } else if (already_gc) {
-            FDB_INFO("Error: Alloc an KV (size %" PRIuLEAST16 ") failed after GC. KV full.\n", kv_size);
+            FDB_INFO("Error: Alloc an KV (size %" PRIuPTR ") failed after GC. KV full.\n", (uintptr_t)kv_size);
             db->gc_request = false;
         }
     }
@@ -1505,8 +1505,8 @@ void fdb_kv_print(fdb_kvdb_t db)
     kv_iterator(db, &kv, &using_size, db, print_kv_cb);
 
     FDB_PRINT("\nmode: next generation\n");
-    FDB_PRINT("size: %" PRIu32 "/%" PRIu32 " bytes.\n", (uint32_t)using_size + ((SECTOR_NUM - FDB_GC_EMPTY_SEC_THRESHOLD) * SECTOR_HDR_DATA_SIZE),
-            db_max_size(db) - db_sec_size(db) * FDB_GC_EMPTY_SEC_THRESHOLD);
+    DB_PRINT("size: %lu/%lu bytes.\n", (unsigned long)((uint32_t)using_size + ((SECTOR_NUM - FDB_GC_EMPTY_SEC_THRESHOLD) * SECTOR_HDR_DATA_SIZE)),
+            (unsigned long)db_max_size(db) - (unsigned long)db_sec_size(db) * FDB_GC_EMPTY_SEC_THRESHOLD);
 
     /* unlock the KV cache */
     db_unlock(db);

--- a/src/fdb_kvdb.c
+++ b/src/fdb_kvdb.c
@@ -1505,7 +1505,7 @@ void fdb_kv_print(fdb_kvdb_t db)
     kv_iterator(db, &kv, &using_size, db, print_kv_cb);
 
     FDB_PRINT("\nmode: next generation\n");
-    DB_PRINT("size: %lu/%lu bytes.\n", (unsigned long)((uint32_t)using_size + ((SECTOR_NUM - FDB_GC_EMPTY_SEC_THRESHOLD) * SECTOR_HDR_DATA_SIZE)),
+    FDB_PRINT("size: %lu/%lu bytes.\n", (unsigned long)((uint32_t)using_size + ((SECTOR_NUM - FDB_GC_EMPTY_SEC_THRESHOLD) * SECTOR_HDR_DATA_SIZE)),
             (unsigned long)db_max_size(db) - (unsigned long)db_sec_size(db) * FDB_GC_EMPTY_SEC_THRESHOLD);
 
     /* unlock the KV cache */


### PR DESCRIPTION
# Warning pulled from compiler fixed
![FlashDB_compilation](https://github.com/user-attachments/assets/c0d287a8-6f5b-43ec-adf7-c7bea116c83b)

## OS tested: `RHEL 8`, `RHEL 9`
This branch contains some changes to original code to cast trought forgot variation of data types moved from a function to another, look up changes to understand my edit.

`status` struct has been initialized to {0, 0} to prevent errors, if any errors occurs while using it, the final code result on DB should not be affected.

also `FDB_PRINT()` has been modified to match the required data types as args on different calls.