### PR TITLE
[tsdb][read_sector_info]: fix flash overwrite when abnormal power loss

### DIFF
--- a/src/fdb_tsdb.c
+++ b/src/fdb_tsdb.c
@@ -238,10 +238,12 @@ static fdb_err_t read_sector_info(fdb_tsdb_t db, uint32_t addr, tsdb_sec_info_t 
 
         tsl.addr.index = sector->empty_idx;
         while (read_tsl(db, &tsl) == FDB_NO_ERR) {
-            if (tsl.status == FDB_TSL_UNUSED || tsl.status == FDB_TSL_PRE_WRITE) {
+            if (tsl.status == FDB_TSL_UNUSED) {
                 break;
             }
-            sector->end_time = tsl.time;
+            if (tsl.status != FDB_TSL_PRE_WRITE) {
+                sector->end_time = tsl.time;
+            }
             sector->end_idx = tsl.addr.index;
             sector->empty_idx += LOG_IDX_DATA_SIZE;
             sector->empty_data -= FDB_WG_ALIGN(tsl.log_len);


### PR DESCRIPTION
https://github.com/armink/FlashDB/pull/302  这个pr确实解决了异常掉电后last time被变为0，但是会导致，上次异常掉电正在写的地址，下次上电后被复写，因为addr没有增加，还是上次FDB_TSL_PRE_WRITE的TSL的地址。