### PR TITLE
Fixed a bug with reversed arguments to the `fwrite` and `fread` functions for `libc` file mode.

### DIFF
--- a/src/fdb_file.c
+++ b/src/fdb_file.c
@@ -263,7 +263,7 @@ fdb_err_t _fdb_file_read(fdb_db_t db, uint32_t addr, void *buf, size_t size)
     FILE *fp = open_db_file(db, addr, false);
     if (fp) {
         addr = addr % db->sec_size;
-        if ((fseek(fp, addr, SEEK_SET) != 0) || (fread(buf, size, 1, fp) != size))
+        if ((fseek(fp, addr, SEEK_SET) != 0) || (fread(buf, size, 1, fp) != 1))
             result = FDB_READ_ERR;
     } else {
         result = FDB_READ_ERR;
@@ -277,7 +277,7 @@ fdb_err_t _fdb_file_write(fdb_db_t db, uint32_t addr, const void *buf, size_t si
     FILE *fp = open_db_file(db, addr, false);
     if (fp) {
         addr = addr % db->sec_size;
-        if ((fseek(fp, addr, SEEK_SET) != 0) || (fwrite(buf, size, 1, fp) != size))
+        if ((fseek(fp, addr, SEEK_SET) != 0) || (fwrite(buf, size, 1, fp) != 1))
             result = FDB_READ_ERR;
         if(sync) {
             fflush(fp);
@@ -285,7 +285,6 @@ fdb_err_t _fdb_file_write(fdb_db_t db, uint32_t addr, const void *buf, size_t si
     } else {
         result = FDB_READ_ERR;
     }
-
     return result;
 }
 


### PR DESCRIPTION
When `FDB_USING_FILE_LIBC_MODE` is enabled, the `libc` functions `fwrite` and `fread` awaited an incorrect return.

Current function calls want to write `size` bytes once, and wait for the size of bytes written to be returned, but the functions return how many times the `size` was written (written as `1` in the code), which always returns `1`, if it succeeds.

```
       On success, fread() and fwrite() return the number of items read
       or written.  This number equals the number of bytes transferred
       only when size is 1.  If an error occurs, or the end of the file
       is reached, the return value is a short item count (or zero).
```
[[source](https://www.man7.org/linux/man-pages/man3/fread.3.html#RETURN_VALUE)]
