### PR TITLE
docs: fix return value of `fdb_kv_get_blob`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ fdb_kv_set_blob(kvdb, "temp", fdb_blob_make(&blob, &temp_data, sizeof(temp_data)
 | db | Database Objects |
 | key | KV name |
 | blob | Return the blob value of KV through the blob object |
-| Return | Error Code |
+| Return | Length of blob data actually read |
 
 Example:
 

--- a/docs/zh-cn/api.md
+++ b/docs/zh-cn/api.md
@@ -135,7 +135,7 @@ fdb_kv_set_blob(kvdb, "temp", fdb_blob_make(&blob, &temp_data, sizeof(temp_data)
 | db   | 数据库对象                            |
 | key  | KV 的名称                             |
 | blob | 通过 blob 对象，返回 KV 的 blob value |
-| 返回 | 错误码                                |
+| 返回 | 实际读取到的 blob 数据长度 |
 
 示例：
 


### PR DESCRIPTION
The documentation states that `fdb_kv_get_blob` returns an error code. In reality, it returns the amount of read bytes.