### PR TITLE
[kvdb] Speed up find by header name_crc gate

### DIFF
--- a/inc/fdb_def.h
+++ b/inc/fdb_def.h
@@ -162,6 +162,7 @@ struct fdb_kv {
     fdb_kv_status_t status;                      /**< node status, @see fdb_kv_status_t */
     bool crc_is_ok;                              /**< node CRC32 check is OK */
     uint8_t name_len;                            /**< name length */
+    uint16_t name_crc;                           /**< KV name's CRC32 low 16bit value (optional fast match) */
     uint32_t magic;                              /**< magic word(`K`, `V`, `4`, `0`) */
     uint32_t len;                                /**< node total length (header + name + value), must align by FDB_WRITE_GRAN */
     uint32_t value_len;                          /**< value length */
@@ -348,4 +349,3 @@ typedef struct fdb_blob *fdb_blob_t;
 #endif
 
 #endif /* _FDB_DEF_H_ */
-


### PR DESCRIPTION
  - 为 KV 头与 struct fdb_kv 补充 name_crc（name CRC32 低 16 位），创建时写入，读取时带出。
  - find_kv 的遍历改为先读头部长度+name_crc，匹配才继续读 name/value 并比对字符串，不匹配直接跳过，减少无缓存扫描Flash      读。
  - kv_iterator 支持可选 search_ctx，兼容未匹配时提前返回；缓存命中/打印/GC 等路径传 NULL 保持旧行为。
  - 补充 <stdint.h> 头，确保类型声明完整。
  - 对旧数据兼容：当头部 name_crc 为擦除态 0xFFFF 时仍继续匹配逻辑。