### PR TITLE
TSDB feature: Added FDB_TSDB_FIXED_BLOB_SIZE compile-time option to reduce flash usage in fixed-size blob scenarios.

### DIFF
--- a/inc/fdb_cfg_template.h
+++ b/inc/fdb_cfg_template.h
@@ -26,7 +26,7 @@
 /* Use fixed-size blobs in TSDB to save flash overhead (8 bytes per entry).
  * Define this to the fixed blob size in bytes when all TSL entries are the same size.
  * Ideal for logging fixed-size sensor data (e.g., float + timestamp).
- * Warning: If defined will be incompataible with variable blob flash store or if fix blob size is later changed */
+ * Warning: If defined will be incompatible with variable blob flash store or if fixed blob size is later changed */
 /* #define FDB_TSDB_FIXED_BLOB_SIZE 4 */
 
 /* Using FAL storage mode */

--- a/src/fdb_tsdb.c
+++ b/src/fdb_tsdb.c
@@ -407,7 +407,7 @@ static fdb_err_t tsl_append(fdb_tsdb_t db, fdb_blob_t blob, fdb_time_t *timestam
     fdb_time_t cur_time = timestamp == NULL ? db->get_time() : *timestamp;
 
 #ifdef FDB_TSDB_FIXED_BLOB_SIZE
-    if(blob->size != FDB_TSDB_FIXED_BLOB_SIZE) {
+    if (blob->size != FDB_TSDB_FIXED_BLOB_SIZE) {
         FDB_INFO("Error: blob size (%zu) must equal FDB_TSDB_FIXED_BLOB_SIZE (%d)\n", blob->size, FDB_TSDB_FIXED_BLOB_SIZE);
         return FDB_WRITE_ERR;
     }


### PR DESCRIPTION
When enabled, removes log_len and log_addr fields from log_idx_data structure, saving 8 bytes per TSL entry. The log address is instead calculated at runtime based on the TSL's position within the sector.

This optimization is ideal for applications logging fixed-size data (e.g., single temperature as float + timestamp) where the 8-byte overhead per entry becomes significant with large numbers of entries.

Changes:
- Conditionally exclude log_len/log_addr from log_idx_data struct
- Calculate log address dynamically in read_tsl() when enabled
- Add strict size validation in tsl_append()