### PR TITLE
Add fdb_tsl_max_blob_count() to get TSDB capacity

### DIFF
--- a/inc/flashdb.h
+++ b/inc/flashdb.h
@@ -65,6 +65,7 @@ void       fdb_tsl_iter        (fdb_tsdb_t db, fdb_tsl_cb cb, void *cb_arg);
 void       fdb_tsl_iter_reverse(fdb_tsdb_t db, fdb_tsl_cb cb, void *cb_arg);
 void       fdb_tsl_iter_by_time(fdb_tsdb_t db, fdb_time_t from, fdb_time_t to, fdb_tsl_cb cb, void *cb_arg);
 size_t     fdb_tsl_query_count (fdb_tsdb_t db, fdb_time_t from, fdb_time_t to, fdb_tsl_status_t status);
+size_t     fdb_tsl_max_blob_count(fdb_tsdb_t db);
 fdb_err_t  fdb_tsl_set_status  (fdb_tsdb_t db, fdb_tsl_t tsl, fdb_tsl_status_t status);
 void       fdb_tsl_clean       (fdb_tsdb_t db);
 fdb_blob_t fdb_tsl_to_blob     (fdb_tsl_t tsl, fdb_blob_t blob);

--- a/src/fdb_tsdb.c
+++ b/src/fdb_tsdb.c
@@ -805,6 +805,28 @@ size_t fdb_tsl_query_count(fdb_tsdb_t db, fdb_time_t from, fdb_time_t to, fdb_ts
 }
 
 /**
+ * Get the maximum number of blobs that a TSL can hold, assuming 
+ * all blobs are max_len (or FDB_TSDB_FIXED_BLOB_SIZE if defined).
+ *
+ * @param db database object
+ * @return the database capacity
+ */
+size_t fdb_tsl_max_blob_count(fdb_tsdb_t db)
+{
+#ifdef FDB_TSDB_FIXED_BLOB_SIZE
+    size_t max_blob_len = FDB_TSDB_FIXED_BLOB_SIZE;
+#else
+    size_t max_blob_len = db->max_len;
+#endif
+
+    size_t sec_size = db_sec_size(db) - SECTOR_HDR_DATA_SIZE;
+    size_t blob_size = LOG_IDX_DATA_SIZE + FDB_WG_ALIGN(max_blob_len);
+    size_t n_sec = db_max_size(db) / db_sec_size(db);
+
+    return n_sec * (sec_size / blob_size);
+}
+
+/**
  * Set the TSL status.
  *
  * @param db database object


### PR DESCRIPTION
It's often useful to know the maximum capacity of a tsdb. I couldn't see any way to get this information already, so this branch adds a function to calculate it. 

The answer will be exact if `FDB_TSDB_FIXED_BLOB_SIZE` is defined, and will be a lower bound if not.